### PR TITLE
Support for sidebar toggling on mobile devices

### DIFF
--- a/components/ChatList.vue
+++ b/components/ChatList.vue
@@ -36,6 +36,7 @@ const store = useChatStore();
 async function openChat(item: ChatItem) {
   store.$patch({ showSetting: false, chat: item });
   await store.getChatMessages(item.id);
+  toggleSideBar();
 }
 </script>
 

--- a/components/ChatSideBar.vue
+++ b/components/ChatSideBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="hidden sm:flex flex-col sm:visible max-w-[1/5] sm:w-1/5 overflow-hidden p-3 bg-slate-100 dark:bg-gray-900 dark:text-slate-300 select-none"
+    class="sm:flex flex-col w-full sm:w-[300px] overflow-hidden p-3 bg-slate-100 dark:bg-gray-900 dark:text-slate-300 select-none"
   >
     <LogoBar />
     <ChatList />

--- a/components/ChatTitleBar.vue
+++ b/components/ChatTitleBar.vue
@@ -3,7 +3,15 @@
     class="flex justify-between items-center bg-white dark:bg-gray-700 dark:text-slate-300 h-14 sm:h-16 pl-2 sm:px-4 border-b"
   >
     <div class="flex items-center space-x-2">
-      <Message size="24" />
+      <div
+        class="icon-btn block sm:hidden dark:hover:text-gray-600"
+        @click="toggleSideBar()"
+      >
+        <HamburgerButton size="22" />
+      </div>
+      <div class="hidden sm:block">
+        <Message size="24" />
+      </div>
       <input
         ref="titleInputDom"
         class="border px-2 py-1 rounded-md"
@@ -25,7 +33,7 @@
     </div>
     <div class="flex items-center">
       <div
-        class="icon-btn dark:hover:text-gray-600"
+        class="icon-btn hidden sm:block dark:hover:text-gray-600"
         @click="store.showHelp = true"
       >
         <Help size="22" />
@@ -33,18 +41,12 @@
       <div class="icon-btn dark:hover:text-gray-600" @click="clearMessages">
         <Clear size="22" />
       </div>
-      <div
-        class="icon-btn block sm:hidden dark:hover:text-gray-600"
-        @click="store.showSetting = true"
-      >
-        <SettingOne size="22" />
-      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Message, Clear, SettingOne, Help } from "@icon-park/vue-next";
+import { HamburgerButton, Message, Clear, Help } from "@icon-park/vue-next";
 import { useChatStore } from "@/stores/chat";
 import { ChatItem } from "@/types";
 

--- a/components/FuncBar.vue
+++ b/components/FuncBar.vue
@@ -26,8 +26,10 @@ const funcs = [
 async function clickBtn(type: string) {
   if (type === "chat") {
     store.createChat();
+    toggleSideBar();
   } else if (type === "setting") {
     store.showSetting = true;
+    toggleSideBar();
   } else if (type === "github") {
     open("https://github.com/lianginx/chatgpt-nuxt", "_blank");
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,9 +6,11 @@
       class="absolute"
       :class="store.showHelp ? 'visible' : 'invisible'"
     />
-    <ChatSideBar />
-    <ChatSetting class="flex-1" v-if="store.showSetting" />
-    <ChatContentBar class="flex-1" v-else />
+    <ChatSideBar id="sidebar" class="sm:visible" />
+    <template id="main" class="hidden sm:visible flex w-screen h-screen">
+      <ChatSetting class="flex-1" v-if="store.showSetting" />
+      <ChatContentBar class="flex-1" v-else />
+    </template>
   </div>
 </template>
 
@@ -43,6 +45,13 @@ onMounted(() => initPage());
 async function initPage() {
   i18n.setLocale(locale.value);
   colorMode.preference = store.getColorMode();
+
+  const clientWidth = document.body.clientWidth;
+  if (clientWidth >= 640) {
+    const mainContent = document.getElementById("main");
+    mainContent?.classList.remove("hidden");
+  }
+
   if (!loadSetting()) store.showSetting = true;
   await store.setNotActiveDbMessages();
   await store.getAllChats();

--- a/utils/toggleSideBar.ts
+++ b/utils/toggleSideBar.ts
@@ -1,0 +1,9 @@
+export const toggleSideBar = () => {
+  const clientWidth = document.body.clientWidth;
+  if (clientWidth < 640) {
+    const sideBar = document.getElementById("sidebar");
+    const mainContent = document.getElementById("main");
+    sideBar?.classList.toggle("hidden");
+    mainContent?.classList.toggle("hidden");
+  }
+};


### PR DESCRIPTION
fix #22

When accessed on a mobile device for the first time, the sidebar is displayed in full-screen.

<img width="200" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/0a5dc2b1-ba36-4d4f-b726-392e3e34855b">

Then, Clicking on any chat room or menu will close the sidebar and transition to the corresponding screen.

<img width="200" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/df845b6c-b49c-4262-b9c4-61ff17384857">

In the chat room, clicking on the hamburger button in the top left corner will once again display the sidebar in full-screen.