### PR TITLE
Fixed layout issues on mobile devices

### DIFF
--- a/components/ChatMessageList.vue
+++ b/components/ChatMessageList.vue
@@ -5,7 +5,7 @@
       :key="item.id"
       :item="item"
     />
-    <div class="h-32"></div>
+    <div class="h-32" />
   </div>
 </template>
 

--- a/components/ChatWelcome.vue
+++ b/components/ChatWelcome.vue
@@ -17,6 +17,7 @@
         {{ $rt(exa.title) }}
       </div>
     </div>
+    <div class="h-32" />
   </div>
 </template>
 


### PR DESCRIPTION
I have fixed the issue where the last sample prompt in the ChatWelcome was getting hidden on mobile devices.

Before
<img width="200" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/dc6fac7c-9f18-45fe-b210-c6e34c05478c">


After
<img width="200" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/ba5b3986-f906-40a8-b130-dcd4e92aded0">
