### PR TITLE
No cursor pointer on the LogoBar

### DIFF
--- a/components/LogoBar.vue
+++ b/components/LogoBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center h-16 px-6 space-x-2 border-b cursor-pointer">
+  <div class="flex items-center h-16 px-6 space-x-2 border-b">
     <Robot size="30" /><span class="text-2xl font-bold">
       {{ $t("app.title") }}
     </span>


### PR DESCRIPTION
The pointer change on LogoBar when the mouse cursor is focused is not necessary since clicking it does not trigger a screen transition.