### PR TITLE
Fix mobile height issue

### DIFF
--- a/components/HotKeyHelp.vue
+++ b/components/HotKeyHelp.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex justify-center items-center z-10 w-full h-full bg-black bg-opacity-30 dark:bg-gray-900 dark:bg-opacity-90"
+    class="flex justify-center items-center z-10 w-full h-screen bg-black bg-opacity-30 dark:bg-gray-900 dark:bg-opacity-90"
   >
     <div
       class="w-5/6 sm:w-3/6 bg-white dark:bg-gray-700 dark:text-slate-300 rounded-lg"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -147,4 +147,10 @@ hotkeys("option+w", (e) => {
 });
 </script>
 
-<style></style>
+<style>
+/* for Mobile height issue */
+.h-screen {
+  height: 100vh; /* Fallback for browsers that do not support Custom Properties */
+  height: 100dvh;
+}
+</style>


### PR DESCRIPTION
In the case of accessing the website using a mobile browser, the content should be displayed entirely without the need for vertical scrolling. However, it appears that scrolling was required in practice.

For example, when entering a message, the text area was hidden below, requiring scrolling.

I have made the necessary changes to eliminate the need for vertical scrolling on mobile browsers.

## Before (Safari, Chrome)

<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/393e8de8-27b9-45fe-bff7-e5ae50e48b59">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/2b720bd2-cbd7-441a-a6e5-9fb3ea4ec584">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/b3df5541-df0d-486f-a36d-67e1dafcaddf">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/7d4b5b8e-fac6-4f75-b055-d7e6a7b60a05">

## After (Safari, Chrome)

<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/b0369f05-1913-4c3a-8871-64b4139a002e">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/05c61bbe-bc3b-434b-91e7-529b578a0eb9">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/ba28c0fe-1eec-4c44-9b50-a48bce797543">
<img width="195" alt="image" src="https://github.com/lianginx/chatgpt-nuxt/assets/61522301/d3fd2b4c-98d8-4869-bede-956db1ff5ecc">
