### PR TITLE
Fix close chat on new chat

### DIFF
--- a/components/ChatList.vue
+++ b/components/ChatList.vue
@@ -22,7 +22,7 @@
       </div>
       <CloseOne
         class="invisible group-hover:visible text-rose-400"
-        @click.stop.left="store.removeChat(item.id)"
+        @click.stop.left="closeChat(item)"
       />
     </div>
 
@@ -69,6 +69,11 @@ async function openChat(item: ChatItem) {
   store.$patch({ showSetting: false, chat: item });
   await store.getChatMessages(item.id);
   toggleSideBar();
+}
+
+async function closeChat(item: ChatItem) {
+  await store.removeChat(item.id);
+  await openChat(store.chats[0]);
 }
 </script>
 


### PR DESCRIPTION
When close button is clicked on a new chat, the chat is only removed from ChatList. This creates confusion on ux logic.
Instead of simply removing chat item from store, this PR fixes by open the first chat from store after removal.