### PR TITLE
fix module issue when "npm install"

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,4 +65,7 @@ export default defineNuxtConfig({
   },
   ssr: false,
   devtools: { enabled: false },
+  alias: {
+    pinia: "/node_modules/@pinia/nuxt/node_modules/pinia/dist/pinia.mjs",
+  },
 });


### PR DESCRIPTION
When I try to use npm install to setup the project, I encounter the following problem.
![before](https://github.com/lianginx/chatgpt-nuxt/assets/68836494/2d886c03-6c34-46bf-a5e7-fadd66786161)

Therefore, I find the solution from stackoverflow, I add the alias for pinia in nuxt.config.ts

So now it can run successfully.
![after](https://github.com/lianginx/chatgpt-nuxt/assets/68836494/dfcf1b51-d070-4aad-add4-bbe5c269c371)
